### PR TITLE
fix: Support for defaultProps will be removed from function components in a future major release

### DIFF
--- a/source/index.tsx
+++ b/source/index.tsx
@@ -61,8 +61,8 @@ render(
 );
 ```
 */
-const Link: ReactFC<Props> = props => ( // eslint-disable-line react/function-component-definition
-	<Transform transform={children => terminalLink(children, props.url, {fallback: props.fallback})}>
+const Link: ReactFC<Props> = ({ children, url, fallback = true }) => ( // eslint-disable-line react/function-component-definition
+	<Transform transform={children => terminalLink(children, url, {fallback: fallback})}>
 		<Text>
 			{props.children}
 		</Text>


### PR DESCRIPTION
Changes:

- The `Link` component is now compatible with future React versions, where `defaultProps` will be removed.
- The code is now more readable and understandable thanks to destructuring props.
- The prop type validation using `PropTypes` remains in place, which improves code reliability and prevents errors.